### PR TITLE
Add a reset token. Fixes #2

### DIFF
--- a/lib/gotgastro.rb
+++ b/lib/gotgastro.rb
@@ -15,6 +15,7 @@ module GotGastro
 
     configure do
       set :morph_api_key, ENV['MORPH_API_KEY']
+      set :reset_token, ENV['GASTRO_RESET_TOKEN']
     end
 
     before do
@@ -60,7 +61,19 @@ module GotGastro
       haml :privacy
     end
 
-    get '/reset' do
+    def self.get_or_post(url,&block)
+      get(url,&block)
+      post(url,&block)
+    end
+
+    get_or_post '/reset' do
+      if params[:token] != settings.reset_token
+        status 404
+        return "ERROR"
+      end
+
+      status 201
+
       reset = Reset.create(:token => params[:token])
 
       Business.dataset.destroy

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -25,7 +25,7 @@ describe 'Got Gastro metrics', :type => :feature do
       "https://api.morph.io/auxesis/gotgastro_scraper/data.json?key&query=select%20*%20from%20'offences'"
       ).to_return(:status => 200, :body => offence_json)
 
-    visit '/reset'
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
     visit '/metrics'
 
     metrics = JSON.parse(body)

--- a/spec/reset_spec.rb
+++ b/spec/reset_spec.rb
@@ -18,16 +18,24 @@ describe 'Data reset', :type => :feature do
       ).to_return(:status => 200, :body => offence_json)
   end
 
+  it 'should require a token' do
+    visit '/reset'
+    expect(page.status_code).to be 404
+
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    expect(page.status_code).to be 201
+  end
+
   it 'should create records' do
     before = Business.count
-    visit '/reset'
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
     after = Business.count
 
     expect(after).to be > before
   end
 
   it 'should create associations' do
-    visit '/reset'
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
 
     Business.each do |biz|
       expect(biz.offences.size).to be > 0
@@ -36,14 +44,14 @@ describe 'Data reset', :type => :feature do
 
   it 'should create a record of the reset' do
     before = Reset.count
-    visit '/reset'
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
     after = Reset.count
 
     expect(after).to be > before
   end
 
   it 'should report the duration of the reset' do
-    visit '/reset'
+    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
 
     expect(Reset.last.duration).to_not be nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,6 @@ def app
   return app
 end
 
+ENV['GASTRO_RESET_TOKEN'] = Digest::MD5.new.hexdigest(Time.now.to_i.to_s)
+
 Capybara.app, _ = app


### PR DESCRIPTION
To limit who can issue a reset, a token must be set at `GASTRO_RESET_TOKEN`, and checked on every request to `/reset`.