### PR TITLE
Handle and indicate running reset

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,6 +37,27 @@ NT, Tasmania, and Queensland don't publish their data.
 | Australian Capital Territory | PDF | http://www.health.act.gov.au/sites/default/files//Register%20of%20Food%20Offences.pdf |
 | Northern Territory | nil |  |
 
+### Metrics
+
+Calls to `/metrics` will return information about how Got Gastro is currently running:
+
+``` json
+{
+  "businesses": 1349,
+  "offences": 2366,
+  "last_reset_at": "2016-10-04T12:01:26.000+00:00",
+  "last_reset_duration": 84
+}
+```
+
+`businesses` and `offences` show counts of each of those data types.
+
+`last_reset_at` is the last time a data reset was performed via API.
+
+`last_reset_duration` is the time it took for the last data reset to complete.
+
+If `last_reset_duration` is `-1`, this means a reset is currently occuring.
+
 ## Developing
 
 ![CircleCI build status](https://circleci.com/gh/auxesis/gastro.png?circle-token=27a395741dc9cb515e2c74222f015b2ffc6c8e2f)
@@ -85,4 +106,3 @@ bundle exec rake
 ## License
 
 Got Gastro is MIT licensed.
-

--- a/lib/gotgastro/models/reset.rb
+++ b/lib/gotgastro/models/reset.rb
@@ -2,6 +2,10 @@ class Reset < Sequel::Model
   plugin :timestamps
 
   def duration
-    self.updated_at - self.created_at
+    if self.updated_at
+      self.updated_at - self.created_at
+    else
+      -1
+    end
   end
 end

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -33,4 +33,26 @@ describe 'Got Gastro metrics', :type => :feature do
     expect(metrics['last_reset_at']).to_not be nil
     expect(metrics['last_reset_duration']).to_not be nil
   end
+
+  it 'should indicate if the current reset is still running' do
+    # This is a bit of a code smell, because it requires poking around the data
+    # structures behind the scenes to simulate a currently running reset
+    # operation.
+    #
+    # Ideally the test could do a request to /reset that blocks for a duration
+    # of time, and in parallel do a request to /metrics to check the last reset
+    # status.
+    #
+    # Of course, this has trade-offs: the test would depend on timely execution,
+    # because the block could complete before the call to /metrics completes.
+    #
+    # The below is an OK trade off for now.
+
+    Reset.create
+    visit '/metrics'
+
+    metrics = JSON.parse(body)
+
+    expect(metrics['last_reset_duration']).to be -1
+  end
 end


### PR DESCRIPTION
 - Currently, calls to /metrics in the middle of a reset will cause a NoMethodError to be thrown. 
 - This happens because the `updated_at` timestamp has never been set, and we try to subtract `updated_at` from `created_at` to determine the duration.
 - We handle this by indicating a reset is currently happening by setting duration to -1
