### PR TITLE
Make display of entry text elements more consistent. Fixes #12:

### DIFF
--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -39,6 +39,29 @@ div.row.detail h4 a {
   color: #333;
 }
 
+div.row.results h4.business-name {
+  margin-bottom: 2px;
+}
+
+div.row.results p.problem-count {
+  margin-bottom: 5px;
+  font-size: 95%;
+}
+
+
+div.row.results p.problem-count.text-warning,
+div.row.results p.problem-count.text-danger {
+  opacity: 0.8;
+}
+
+div.row.results p.problem-count.text-danger span.badge {
+  background-color: #ff4136;
+}
+
+div.row.results p.problem-count.text-warning span.badge {
+  background-color: #ff851b;
+}
+
 div.row.results div.result {
   border-bottom: 1px solid lightgray;
 }

--- a/lib/views/search.haml
+++ b/lib/views/search.haml
@@ -31,13 +31,17 @@
         %div.col-md-12.result
           %div.pull-right.distance
             = "%.1f" % business.distance_from(@location) + "km away"
-          %h4
+          %h4.business-name
             %a{:href => link_to("/business/#{business.id}")}
               = business.name
+          - c = case
+          - when business.problems <= 2; 'warning'
+          - when business.problems > 2; 'danger'
+          %p.problem-count{:class => "text-#{c}"}
             %small
-              - word = business.problems == 1 ? "problem" : "problems"
-              = "#{business.problems} #{word}"
-          %p.text-muted
+              %span.badge= business.problems
+              = business.problems == 1 ? 'problem' : 'problems'
+          %p.address.text-muted
             %small= business.address
     - else
       %div.col-md-12.result.text-center.empty


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/12306/19141758/dab28996-8be3-11e6-81ad-65409d7f6443.png)

After:

![image](https://cloud.githubusercontent.com/assets/12306/19141753/ca47bbf8-8be3-11e6-916f-8a8a106759c0.png)

Details:

 - Put problem count onto own line, for consistent left alignment.
 - Make the problem count font size smaller, to not overshadow text
   elements above and below.
 - Color the line based on the number of problems listed against the
   business name.
 - Lessen the paragraph margin, to minimise vertical sprawl of the
   entry.

