### PR TITLE
Uppercase business name

### DIFF
--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -41,6 +41,7 @@ div.row.detail h4 a {
 
 div.row.results h4.business-name {
   margin-bottom: 2px;
+  text-transform: uppercase;
 }
 
 div.row.results p.problem-count {


### PR DESCRIPTION
So it displays the same regardless of data source. 

Before: 

![image](https://cloud.githubusercontent.com/assets/12306/19141895/f73b35d0-8be4-11e6-94ab-7ea06f6fc8ba.png)

After:

![image](https://cloud.githubusercontent.com/assets/12306/19141891/ece2c044-8be4-11e6-9ecc-5e175a1fac99.png)
