### PR TITLE
Improve detail layout

### DIFF
--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -72,11 +72,6 @@ div.row.detail  p.problem-count.text-warning span.badge  /* detail */
   background-color: #ff851b;
 }
 
-div.row.detail h3.problem-count {
-  font-weight: bold;
-  margin-top: 10px;
-}
-
 div.row.results div.result {
   border-bottom: 1px solid lightgray;
 }

--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -23,6 +23,10 @@ button.geolocation {
   }
 }
 
+div.row {
+  cursor: pointer;
+}
+
 div.row.landing p {
   margin-bottom: 15px;
 }

--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -82,6 +82,17 @@ div.row.results div.result.empty {
   padding: 16px 24px 24px;
 }
 
+div.row.results div.distance {
+  padding-left: 5px;
+  margin-top: 6px;
+}
+
+@media (max-width: 768px) {
+  div.row.results div.distance {
+    margin-top: -3px;
+  }
+}
+
 div.row.nav {
   margin-top: 7.5px;
 }

--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -23,16 +23,24 @@ button.geolocation {
   }
 }
 
-div.row {
-  cursor: pointer;
-}
-
 div.row.landing p {
   margin-bottom: 15px;
 }
 
 div.row p.map img {
   width: 100%;
+}
+
+div.row.results {
+  cursor: pointer;
+}
+
+div.row.results div.result:hover {
+  background-color: #f9f9f9;
+}
+
+div.row.results a:hover {
+  text-decoration: none;
 }
 
 div.row.results h4,

--- a/lib/public/css/main.css
+++ b/lib/public/css/main.css
@@ -44,23 +44,37 @@ div.row.results h4.business-name {
   text-transform: uppercase;
 }
 
-div.row.results p.problem-count {
+div.row.results p.problem-count, /* search */
+div.row.detail p.problem-count /* detail */
+{
   margin-bottom: 5px;
   font-size: 95%;
 }
 
 
-div.row.results p.problem-count.text-warning,
-div.row.results p.problem-count.text-danger {
+div.row.results p.problem-count.text-warning, /* search */
+div.row.results p.problem-count.text-danger,
+div.row.detail p.problem-count.text-warning, /* detail */
+div.row.detail p.problem-count.text-danger
+{
   opacity: 0.8;
 }
 
-div.row.results p.problem-count.text-danger span.badge {
+div.row.results p.problem-count.text-danger span.badge, /* search */
+div.row.detail p.problem-count.text-danger span.badge   /* detail */
+{
   background-color: #ff4136;
 }
 
-div.row.results p.problem-count.text-warning span.badge {
+div.row.results p.problem-count.text-warning span.badge, /* search */
+div.row.detail  p.problem-count.text-warning span.badge  /* detail */
+{
   background-color: #ff851b;
+}
+
+div.row.detail h3.problem-count {
+  font-weight: bold;
+  margin-top: 10px;
 }
 
 div.row.results div.result {

--- a/lib/views/detail.haml
+++ b/lib/views/detail.haml
@@ -12,20 +12,40 @@
         %img{:src => map_url}/
   %div.row.detail
     %div.col-md-12
-      %div.pull-right
-        = "%.1f" % @business.distance_from(@location) + "km away"
-      %p.text-muted
-        %small= @business.address
-      %h4
-        Offences:
+      %p.text-muted= @business.address
+      - c = case
+      - when @business.problems <= 2; 'warning'
+      - when @business.problems > 2; 'danger'
+    %div.col-md-6
+      %div.alert{:class => "alert-#{c}"}
+        %i.fa.fa-fw.fa-lg.fa-exclamation-circle
         = @business.problems
+        = @business.problems == 1 ? 'problem' : 'problems'
+    %div.col-md-6
+      %div.alert.alert-info
+        %i.fa.fa-fw.fa-lg.fa-location-arrow
+        = "%.1f" % @business.distance_from(@location) + "km away"
+
+  %div.row.detail
     %div.col-md-12
-      %h4 Date of offences
+      - dates = @business.offences.map(&:date).uniq
+      %h4
+        - case
+        - when @business.offences.count == 1
+          Date of offence
+        - when @business.offences.count > 1 && dates.size == 1
+          Date of offences
+        - else
+          Dates of offences
       %ul
-        - @business.offences.map(&:date).uniq.each do |date|
+        - dates.each do |date|
           %li= date
     %div.col-md-12
-      %h4 Offence details
+      %h4
+        - if @business.offences.count == 1
+          Details of offence
+        - else
+          Details of offences
       %ul
         - @business.offences.each do |offence|
           - if offence.description =~ /\n/
@@ -33,20 +53,6 @@
               %pre= offence.description
           - else
             %li= offence.description
-  %div.row
-    %div.col-md-12
-      %ul.list-inline
-        %li
-          %strong Share:
-        %li
-          %button.btn.btn-info
-            %i.fa.fa-fw.fa-lg.fa-twitter
-        %li
-          %button.btn.btn-primary
-            %i.fa.fa-fw.fa-lg.fa-facebook
-        %li
-          %button.btn.btn-warning
-            %i.fa.fa-fw.fa-lg.fa-envelope
   %div.row.nav
     %div.col-md-12
       %p


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/12306/19149425/85cf3756-8c0d-11e6-8395-2161cf712b28.png)

After:

![image](https://cloud.githubusercontent.com/assets/12306/19149472/a77b8a30-8c0d-11e6-96ad-b7f0542eff4a.png)

Summary:

 - Call out problem count and distance.
 - Appropriately pluralise terms based on count of offences, and offence
   dates.
 - Remove social media share buttons, because they don't currently work.

Also:

 - Align baselines of business names and distance, so they're not misaligned.

Before: 

![image](https://cloud.githubusercontent.com/assets/12306/19149409/74e60168-8c0d-11e6-9541-6ece3501c579.png)

After:

![image](https://cloud.githubusercontent.com/assets/12306/19149488/bb8ec58c-8c0d-11e6-9181-c2caa622486c.png)
