### PR TITLE
Move alert signup into a service object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'rack-ssl'
 gem 'rest-client'
 gem 'activesupport'
 gem 'mail'
+gem 'virtus'
+gem 'activemodel'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
+      builder (~> 3.1)
     activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -21,6 +24,10 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     backports (3.6.8)
     builder (3.2.2)
     capybara (2.5.0)
@@ -30,11 +37,16 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     coderay (1.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
+    equalizer (0.0.11)
     erubis (2.7.0)
     ffi (1.9.10)
     foreman (0.78.0)
@@ -46,6 +58,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    ice_nine (0.11.2)
     json (1.8.3)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
@@ -133,6 +146,11 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -144,6 +162,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activemodel
   activesupport
   bundler
   capybara
@@ -164,6 +183,7 @@ DEPENDENCIES
   sequel_mappable
   sinatra
   sinatra-contrib
+  virtus
   webmock
 
 RUBY VERSION

--- a/db/migrations/007_create_alerts_table.rb
+++ b/db/migrations/007_create_alerts_table.rb
@@ -4,6 +4,7 @@ class CreateAlertsTable < Sequel::Migration
       primary_key :id
       Time        :created_at
       Time        :updated_at
+      Time        :confirmed_at
       String      :email
       Float       :lat
       Float       :lng

--- a/lib/gotgastro.rb
+++ b/lib/gotgastro.rb
@@ -76,7 +76,7 @@ module GotGastro
       @alert = Alert.create(params[:alert])
 
       email = @alert.email
-      link = link_to("/alerts/confirm/#{@alert.confirmation_id}")
+      link = link_to("/alert/#{@alert.confirmation_id}/confirm")
 
       mail = Mail.new do
         from     'alerts-confirm@gotgastroagain.com'
@@ -87,6 +87,17 @@ module GotGastro
       mail.deliver!
 
       haml :alert
+    end
+
+    get '/alert/:confirmation_id/confirm' do
+      @alert = Alert.first(:confirmation_id => params[:confirmation_id])
+      if @alert
+        @alert.confirmed_at = Time.now
+        @alert.save
+        haml :alert_confirmation
+      else
+        status 404
+      end
     end
 
     def self.get_or_post(url,&block)

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -84,6 +84,8 @@ module Sequel
   end
 end
 
+# Initialise services for handling data
+require 'gotgastro/services'
 
 # Stub out any data backfilling we need to do.
 class Backfill
@@ -91,3 +93,4 @@ class Backfill
   end
 end
 Backfill.run!
+

--- a/lib/gotgastro/models/alert.rb
+++ b/lib/gotgastro/models/alert.rb
@@ -1,6 +1,10 @@
 class Alert < Sequel::Model
   plugin :timestamps
 
+  def location
+    [self.lat, self.lng].join(',')
+  end
+
   def location=(value)
     lat, lng = value.split(',')
     self.lat = lat

--- a/lib/gotgastro/models/alert.rb
+++ b/lib/gotgastro/models/alert.rb
@@ -10,9 +10,4 @@ class Alert < Sequel::Model
     self.lat = lat
     self.lng = lng
   end
-
-  def before_create
-    id = Digest::MD5.new.hexdigest("#{rand(created_at.to_i).to_s}-#{self.email}")
-    self.confirmation_id = id
-  end
 end

--- a/lib/gotgastro/services.rb
+++ b/lib/gotgastro/services.rb
@@ -1,0 +1,5 @@
+require 'virtus'
+require 'active_model'
+
+services_path = Pathname.new(__FILE__).parent.join('services').join('*.rb')
+Dir.glob(services_path).each { |service| require(service) }

--- a/lib/gotgastro/services/alert_signup_service.rb
+++ b/lib/gotgastro/services/alert_signup_service.rb
@@ -1,0 +1,82 @@
+class AlertSignupService
+  include Virtus.model
+
+  extend ActiveModel::Naming
+  include ActiveModel::Conversion
+  include ActiveModel::Validations
+
+  attr_reader :user
+
+  attribute :email, String
+  attribute :location, String
+  attribute :distance, Float
+
+  validates :email, presence: { :message => 'Bummer! We need an email address to create an alert for you.' }
+  validates :location, presence: {}
+  validates :distance, presence: {}
+
+  def initialize(opts)
+    @host = opts[:host] || 'https://gotgastroagain.com'
+    @alert = opts[:alert] if opts[:alert]
+    super(opts)
+  end
+
+  def persisted?
+    false
+  end
+
+  def save
+    if valid?
+      persist!
+      notify!
+      true
+    else
+      false
+    end
+  end
+
+  def self.find(confirmation_id)
+    alert = Alert.first(:confirmation_id => confirmation_id)
+    if alert
+      self.new(:alert => alert)
+    else
+      nil
+    end
+  end
+
+  def confirm!
+    @alert.confirmed_at = Time.now
+    @alert.save
+  end
+
+private
+
+  def persist!
+    attrs = {
+      :email    => email,
+      :location => location,
+      :distance => distance,
+      :confirmation_id => Digest::MD5.new.hexdigest("#{rand(Time.now.to_i).to_s}-#{email}")
+    }
+    @alert = Alert.create(attrs)
+  end
+
+  def notify!
+    mail = Mail.new
+    mail.from    = 'alert-confirm@gotgastroagain.com'
+    mail.to      = email
+    mail.subject = 'Please confirm your Got Gastro alert'
+    mail.body    = <<-BODY.gsub(/^ {6}/, '')
+      Hello!
+      Please confirm your signup for a Got Gastro alert by following this link:
+
+      #{@host}/alert/#{@alert.confirmation_id}/confirm
+
+      If you don't know what this means, feel free to ignore this email.
+
+      Thanks,
+      Got Gastro
+    BODY
+    mail.deliver
+  end
+end

--- a/lib/views/alert_confirmation.haml
+++ b/lib/views/alert_confirmation.haml
@@ -1,0 +1,30 @@
+- page_title 'Your alert is activated'
+
+%div.container
+  %div.row
+    %div.col-md-12
+      %h1
+        %i.fa.fa-check-circle-o
+        Thank you! Your alert is now activated.
+      %p
+        You will now receive email alerts for any planning applications
+        we find within
+        = "#{@alert.distance}km"
+        of
+        = @alert.location
+      %p
+        You can change the size of the area covered by the alert now or
+        at a later time. Every email alert will have this link.
+      %p
+        If you want alerts around another address, you can
+        %a{:href => '/'} sign up for multiple alerts.
+
+  %div.row.nav
+    %div.col-md-12
+      %p
+        %a{:href => "/"}
+          %button.btn.btn-default{:type => 'button'}
+            %i.fa.fa-fw.fa-arrow-circle-o-left
+            Back to search
+
+  = haml :footer

--- a/spec/alerts_spec.rb
+++ b/spec/alerts_spec.rb
@@ -26,7 +26,7 @@ describe 'Alerts', :type => :feature do
     Mail::TestMailer.deliveries.clear
   end
 
-  it 'should send a confirmation mail on sign up' do
+  it 'should allow a user to subscribe' do
     within_25km && within_150km
 
     visit "/search?lat=#{origin.lat}&lng=#{origin.lng}&alert=hello"
@@ -34,5 +34,19 @@ describe 'Alerts', :type => :feature do
     click_on 'Create alert'
 
     expect(Mail::TestMailer.deliveries.size).to be 1
+
+    confirmation_link = Mail::TestMailer.deliveries.first.body.to_s
+    visit(confirmation_link)
+    expect(page.status_code).to be 200
+    expect(page.body).to match(/your alert is now activated/i)
+  end
+
+  it 'should mail notifications when new offences are added'
+  it 'should not send notifications if the alert is not confirmed'
+  it 'should allow a user to unsubscribe'
+
+  it 'should deny unknown confirmations' do
+    visit '/alert/12345/confirm'
+    expect(page.status_code).to be 404
   end
 end

--- a/spec/alerts_spec.rb
+++ b/spec/alerts_spec.rb
@@ -35,7 +35,7 @@ describe 'Alerts', :type => :feature do
 
     expect(Mail::TestMailer.deliveries.size).to be 1
 
-    confirmation_link = Mail::TestMailer.deliveries.first.body.to_s
+    confirmation_link = Mail::TestMailer.deliveries.first.body.to_s.match(/^(http.*)$/, 1)
     visit(confirmation_link)
     expect(page.status_code).to be 200
     expect(page.body).to match(/your alert is now activated/i)


### PR DESCRIPTION
To better separate models and business logic. 

This makes the code easier to understand and follow. 