### PR TITLE
Make data reset asynchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 *.sublime-project
 *.sublime-workspace
 .idea/
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'activesupport'
 gem 'mail'
 gem 'virtus'
 gem 'activemodel'
+gem 'sidekiq'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
     coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.0.2)
+    connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     daemons (1.2.4)
@@ -50,7 +52,7 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
-    ffi (1.9.10)
+    ffi (1.9.14)
     foreman (0.78.0)
       thor (~> 0.19.1)
     geokit (1.10.0)
@@ -62,9 +64,10 @@ GEM
     i18n (0.7.0)
     ice_nine (0.11.2)
     json (1.8.3)
-    listen (3.0.5)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -111,8 +114,9 @@ GEM
       loofah (~> 2.0)
     rake (10.4.2)
     rb-fsevent (0.9.7)
-    rb-inotify (0.9.5)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.1)
     rerun (0.11.0)
       listen (~> 3.0)
     rest-client (2.0.0)
@@ -132,10 +136,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    ruby_dep (1.4.0)
     safe_yaml (1.0.4)
     sequel (4.33.0)
     sequel_mappable (0.0.1)
       geokit (>= 1.5.0)
+    sidekiq (4.2.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (~> 1.5)
+      redis (~> 3.2, >= 3.2.1)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -200,6 +210,7 @@ DEPENDENCIES
   rspec
   sequel
   sequel_mappable
+  sidekiq
   sinatra
   sinatra-contrib
   virtus

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -e production -p $PORT -S ~/puma
+sidekiq: bundle exec sidekiq -c 2 -v -r ./lib/gotgastro/workers.rb

--- a/Procfile.development
+++ b/Procfile.development
@@ -1,2 +1,4 @@
 web: pkill -f rackup ; bundle exec rerun --pattern='**/*.{rb,ru}' --ignore='spec/*' -- rackup -o 0.0.0.0
 mail: mailcatcher -f
+redis: redis-server
+sidekiq: bundle exec rerun --pattern=lib/gotgastro/workers* -- sidekiq -c 10 -v -r ./lib/gotgastro/workers.rb

--- a/README.markdown
+++ b/README.markdown
@@ -72,7 +72,7 @@ Got Gastro runs on [Pivotal Web Services](https://run.pivotal.io/).
 
 ### Setup
 
-Ensure you have Git, Ruby, and MySQL:
+Ensure you have Git, Ruby, MySQL, and Redis:
 
 ``` bash
 git clone git@github.com:auxesis/gastro.git
@@ -81,9 +81,17 @@ bundle
 rake db:setup
 ```
 
-_MySQL is required due to OGC spatial analysis functions. In theory it should work with Postgres too, but is untested._
+#### MySQL
 
-_The Rake tasks assume you have a root user with no password set_
+MySQL is required due to OGC spatial analysis functions. In theory it should work with Postgres too, but is untested.
+
+The Rake tasks assume your MySQL root user with no password set.
+
+#### Redis
+
+Redis is required for queueing jobs. It's started by Foreman automatically with the commands below in [Running](#running).
+
+Foreman assumes you have `redis-server` on your path.
 
 ### Running
 

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -100,6 +100,9 @@ end
 # Initialise services for handling data
 require 'gotgastro/services'
 
+# Initialise workers for background jobs
+require 'gotgastro/workers'
+
 # Stub out any data backfilling we need to do.
 class Backfill
   def self.run!

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -167,4 +167,13 @@ when 'production'
       :enable_starttls_auto => true,
     }
   end
+
+  credentials  = config['vcap_services']['rediscloud'].first['credentials']
+  redis_config = {
+    :url      => "redis://#{credentials['hostname']}:#{credentials['port']}/0",
+    :password => credentials['password']
+  }
+
+  Sidekiq.configure_server {|c| c.redis = redis_config }
+  Sidekiq.configure_client {|c| c.redis = redis_config }
 end

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -33,6 +33,22 @@ def info(msg)
   puts('[info] ' + msg) if info?
 end
 
+def set_or_error(config, key, value)
+  case
+  when value.nil? || value.blank?
+    raise ArgumentError, "Value for '#{key}' was not specified"
+  when value.respond_to?(:[]) && value[:env]
+    v = value[:env]
+    if ENV[v]
+      config[key] = ENV[v]
+    else
+      raise ArgumentError, "'#{v}' envvar (value for '#{key}') was not specified"
+    end
+  else
+    config[key] = value
+  end
+end
+
 def config
   return @vcap if @vcap
 

--- a/lib/gotgastro/workers.rb
+++ b/lib/gotgastro/workers.rb
@@ -1,0 +1,10 @@
+$: << File.expand_path(File.join(__FILE__, '..', '..'))
+
+require 'rubygems'
+require 'gotgastro/initializer'
+require 'sidekiq'
+require 'redis'
+require 'sidekiq/api'
+
+workers_path = Pathname.new(__FILE__).parent.join('workers').join('*.rb')
+Dir.glob(workers_path).each { |worker| require(worker) }

--- a/lib/gotgastro/workers/reset_worker.rb
+++ b/lib/gotgastro/workers/reset_worker.rb
@@ -1,0 +1,48 @@
+require 'sidekiq'
+require 'redis'
+require 'sidekiq/api'
+require 'rest-client'
+
+module GotGastro
+  module Workers
+    class ResetWorker
+      include Sidekiq::Worker
+
+      def perform(token)
+        reset = Reset.create(:token => token)
+        info("Data reset started at #{reset.created_at}")
+
+        Business.dataset.destroy
+        Offence.dataset.destroy
+
+        url = 'https://api.morph.io/auxesis/gotgastro_scraper/data.json'
+
+        # Create Businesses
+        params = {
+          :key => config['settings']['morph_api_key'],
+          :query => "select * from 'businesses'"
+        }
+        result = RestClient.get(url, :params => params)
+        businesses = JSON.parse(result)
+
+        Business.unrestrict_primary_key
+        businesses.each do |business|
+          Business.create(business)
+        end
+
+        # Create Offences
+        params = { :key => config['settings']['morph_api_key'], :query => "select * from 'offences'" }
+        result = RestClient.get(url, :params => params)
+        offences = JSON.parse(result)
+
+        Offence.unrestrict_primary_key
+        offences.each do |offence|
+          Offence.create(offence)
+        end
+
+        reset.save
+        info("Data reset completed at #{reset.updated_at}")
+      end
+    end
+  end
+end

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -26,6 +26,7 @@ describe 'Got Gastro metrics', :type => :feature do
       ).to_return(:status => 200, :body => offence_json)
 
     visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    GotGastro::Workers::ResetWorker.drain
     visit '/metrics'
 
     metrics = JSON.parse(body)

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 include Rack::Test::Methods
+include GotGastro::Env::Test
 
 describe 'Got Gastro metrics', :type => :feature do
   it 'should expose counts of core data' do
@@ -15,6 +16,8 @@ describe 'Got Gastro metrics', :type => :feature do
   let(:mocks) { Pathname.new(__FILE__).parent.join('mocks') }
   let(:business_json) { mocks.join('businesses.json').read }
   let(:offence_json) { mocks.join('offences.json').read }
+  let(:gastro_reset_token) { Digest::MD5.new.hexdigest(rand(Time.now.to_i).to_s) }
+  let(:morph_api_key) { Digest::MD5.new.hexdigest(rand(Time.now.to_i).to_s) }
 
   it 'should expose metrics from last reset' do
     stub_request(:get,
@@ -25,7 +28,10 @@ describe 'Got Gastro metrics', :type => :feature do
       %r{https://api\.morph\.io/auxesis/gotgastro_scraper/data\.json\?key.*&query=select%20\*%20from%20'offences'}
       ).to_return(:status => 200, :body => offence_json)
 
-    visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+
+    visit "/reset?token=#{gastro_reset_token}"
     GotGastro::Workers::ResetWorker.drain
     visit '/metrics'
 

--- a/spec/reset_spec.rb
+++ b/spec/reset_spec.rb
@@ -18,11 +18,23 @@ describe 'Data reset', :type => :feature do
       ).to_return(:status => 200, :body => offence_json)
   end
 
-  it 'should error if setttings value is not set' do
-    # This isn't so great, because we're testing implementation (set_or_raise)
-    # not the interface (booting the app without environment variables).
+  after(:each) do
+    if @original
+      ENV.replace(@original)
+      @original = nil
+    end
+  end
+
+  def delete_environment_variable(name)
+    @original ||= ENV.to_hash
+    ENV.delete(name)
+  end
+
+  it 'should error if config is not set' do
     expect {
-      GotGastro::App.new.settings.set_or_raise(:hello, nil)
+      delete_environment_variable('GASTRO_RESET_TOKEN')
+      delete_environment_variable('MORPH_API_KEY')
+      config
     }.to raise_error(ArgumentError)
   end
 

--- a/spec/reset_spec.rb
+++ b/spec/reset_spec.rb
@@ -37,13 +37,14 @@ describe 'Data reset', :type => :feature do
   it 'should create records' do
     before = Business.count
     visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    GotGastro::Workers::ResetWorker.drain
     after = Business.count
-
     expect(after).to be > before
   end
 
   it 'should create associations' do
     visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    GotGastro::Workers::ResetWorker.drain
 
     Business.each do |biz|
       expect(biz.offences.size).to be > 0
@@ -53,6 +54,7 @@ describe 'Data reset', :type => :feature do
   it 'should create a record of the reset' do
     before = Reset.count
     visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    GotGastro::Workers::ResetWorker.drain
     after = Reset.count
 
     expect(after).to be > before
@@ -60,6 +62,7 @@ describe 'Data reset', :type => :feature do
 
   it 'should report the duration of the reset' do
     visit "/reset?token=#{ENV['GASTRO_RESET_TOKEN']}"
+    GotGastro::Workers::ResetWorker.drain
 
     expect(Reset.last.duration).to_not be nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def app
   return app
 end
 
-ENV['GASTRO_RESET_TOKEN'] = Digest::MD5.new.hexdigest(Time.now.to_i.to_s)
-ENV['MORPH_API_KEY'] = Digest::MD5.new.hexdigest((Time.now.to_i + 10).to_s)
+ENV['GASTRO_RESET_TOKEN'] = Digest::MD5.new.hexdigest(rand(Time.now.to_i).to_s)
+ENV['MORPH_API_KEY'] = Digest::MD5.new.hexdigest(rand(Time.now.to_i).to_s)
 
 Capybara.app, _ = app

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rack/test'
 require 'pry'
 require 'webmock/rspec'
 require 'mail'
+require 'sidekiq/testing'
 
 RSpec.configure do |config|
   # Use color not only in STDOUT but also in pagers and files
@@ -22,11 +23,17 @@ RSpec.configure do |config|
   config.around(:each) do |example|
     DB.transaction(:rollback=>:always, :auto_savepoint=>true){example.run}
   end
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 end
 
 Mail.defaults do
   delivery_method :test
 end
+
+Sidekiq::Testing.fake!
 
 # Define the Rack::Test/Capybara app by reading in the config.ru
 def app


### PR DESCRIPTION
Currently requests to `/reset` are handled synchronously. 

This frequently causes problems when Morph's webhooks call `/reset` to trigger a new data load – the Cloud Foundry router times out the connection with a 504 and Morph just sees an error.

This PR introduces Sidekiq as a queueing system for Got Gastro. Calls to `/reset` complete instantly, but the data reset is now handled by a worker. 

Once queueing is introduced, we will be able to effectively implement daily email alerts. 