### PR TITLE
Remove credentials, make use of New Relic production grade

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -5,7 +5,7 @@ common: &default_settings
   # You must specify the license key associated with your New Relic
   # account.  This key binds your Agent's data to your account in the
   # New Relic service.
-  license_key: '1085ad197af5ed6053792d87a81fb9bcadd47b2c'
+  license_key: '<%= config["settings"]["newrelic_license_key"] %>'
 
   # Agent Enabled (Ruby/Rails Only)
   # Use this setting to force the agent to run or not run.
@@ -181,15 +181,14 @@ common: &default_settings
 development:
   <<: *default_settings
   # Turn on communication to New Relic service in development mode
-  monitor_mode: true
-  app_name: gotgastro (development)
+  monitor_mode: false
 
   # Rails Only - when running in Developer Mode, the New Relic Agent will
   # present performance information on the last 100 transactions you have
   # executed since starting the mongrel.
   # NOTE: There is substantial overhead when running in developer mode.
   # Do not use for production or load testing.
-  developer_mode: true
+  developer_mode: false
 
 test:
   <<: *default_settings

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -4,6 +4,7 @@ require 'ostruct'
 require 'erb'
 require 'json'
 require 'mail'
+require 'newrelic_rpm'
 
 def root
   @root ||= Pathname.new(__FILE__).parent.parent.parent
@@ -60,8 +61,14 @@ def config
 
   # FIXME(auxesis): refactor this to recursive openstruct
   settings = {}
-  set_or_error(settings, 'reset_token',   :env => 'GASTRO_RESET_TOKEN')
-  set_or_error(settings, 'morph_api_key', :env => 'MORPH_API_KEY')
+  begin
+    set_or_error(settings, 'reset_token',   :env => 'GASTRO_RESET_TOKEN')
+    set_or_error(settings, 'morph_api_key', :env => 'MORPH_API_KEY')
+    set_or_error(settings, 'newrelic_license_key', :env => 'NEWRELIC_LICENSE_KEY') if environment == 'production'
+  rescue ArgumentError => e
+    @vcap = nil
+    raise e
+  end
   debug("settings: #{settings.inspect}")
   @vcap.merge!('settings' => settings)
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+include Rack::Test::Methods
+include GotGastro::Env::Test
+
+describe 'Config', :type => :feature do
+  include_context 'test data'
+
+  before(:each) do
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+  end
+
+  it 'should expose config sourced from environment variables' do
+    expect(config['settings']['reset_token']).to eq(gastro_reset_token)
+    expect(config['settings']['morph_api_key']).to eq(morph_api_key)
+  end
+
+  it 'should error if config is not set' do
+    expect {
+      delete_environment_variable('GASTRO_RESET_TOKEN')
+      delete_environment_variable('MORPH_API_KEY')
+      config
+    }.to raise_error(ArgumentError)
+  end
+
+  it 'should continue to error if config is not set' do
+    expect {
+      delete_environment_variable('GASTRO_RESET_TOKEN')
+      delete_environment_variable('MORPH_API_KEY')
+      config
+    }.to raise_error(ArgumentError)
+
+    expect {
+      delete_environment_variable('GASTRO_RESET_TOKEN')
+      delete_environment_variable('MORPH_API_KEY')
+      config
+    }.to raise_error(ArgumentError)
+  end
+
+end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -21,14 +21,6 @@ describe 'Data import', :type => :feature do
     set_environment_variable('MORPH_API_KEY', morph_api_key)
   end
 
-  it 'should error if config is not set' do
-    expect {
-      delete_environment_variable('GASTRO_RESET_TOKEN')
-      delete_environment_variable('MORPH_API_KEY')
-      config
-    }.to raise_error(ArgumentError)
-  end
-
   it 'should require a token' do
     visit '/reset'
     expect(page.status_code).to be 404


### PR DESCRIPTION
 - Move NR credentials into an environment variable, so the config is
   separate from the app.
 - Disable NR in all environments but production, because it should be
   something the developer explicitly turns on in other environments.
 - Refactor config lookup tests into a separate spec, because they're
   getting complex enough to deserve their own tests.
 - Fix a bug where the config method will return an empty hash if
   previous calls to the config method raised an exception.