### PR TITLE
Change alert distance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,5 @@ group :test do
   gem 'capybara'
   gem 'webmock'
   gem 'delorean'
+  gem 'faker'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
+    faker (1.6.6)
+      i18n (~> 0.5)
     ffi (1.9.14)
     foreman (0.78.0)
       thor (~> 0.19.1)
@@ -204,6 +206,7 @@ DEPENDENCIES
   capybara
   delorean
   dotiw
+  faker
   foreman
   geokit
   haml

--- a/lib/gotgastro.rb
+++ b/lib/gotgastro.rb
@@ -99,6 +99,34 @@ module GotGastro
       end
     end
 
+    get '/alert/:confirmation_id/edit' do
+      @alert = Alert.first(:confirmation_id => params[:confirmation_id])
+      if @alert
+        haml :alert_edit
+      else
+        status 404
+      end
+    end
+
+    def flash
+      @flash ||= {}
+    end
+
+    post '/alert/:confirmation_id/edit' do
+      @alert = Alert.first(:confirmation_id => params[:confirmation_id])
+      if @alert
+        @alert.distance = params[:alert][:distance]
+        if @alert.save
+          flash[:success] = 'Alert updated!'
+        else
+          flash[:danger] = 'There was a problem updating your alert :-('
+        end
+        haml :alert_edit
+      else
+        status 404
+      end
+    end
+
     def self.get_or_post(url,&block)
       get(url,&block)
       post(url,&block)

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -61,6 +61,7 @@ def config
 
   # FIXME(auxesis): refactor this to recursive openstruct
   settings = {}
+  settings['baseurl'] = environment == 'production' ? 'https://gotgastroagain.com' : 'http://localhost:9292'
   begin
     set_or_error(settings, 'reset_token',   :env => 'GASTRO_RESET_TOKEN')
     set_or_error(settings, 'morph_api_key', :env => 'MORPH_API_KEY')

--- a/lib/gotgastro/models.rb
+++ b/lib/gotgastro/models.rb
@@ -5,6 +5,7 @@ require 'geokit'
 Sequel::Model.plugin :dataset_associations
 Sequel::Model.plugin :timestamps, :update_on_create => true
 Sequel::Model.plugin :validation_helpers
+Sequel::Model.plugin :table_select
 
 models_path = Pathname.new(__FILE__).parent.join('models').join('*.rb')
 models = Dir.glob(models_path)

--- a/lib/gotgastro/models/business.rb
+++ b/lib/gotgastro/models/business.rb
@@ -10,8 +10,9 @@ class Business < Sequel::Model
     end
   end
 
-  def distance_from(loc)
-    self.class.distance_between(self, loc, :units => :kms)
+  def distance_from(loc, options={})
+    opts = {:units => :kms}.merge(options)
+    self.class.distance_between(self, loc, opts)
   end
 
   def problems

--- a/lib/gotgastro/workers/email_alerts.rb
+++ b/lib/gotgastro/workers/email_alerts.rb
@@ -48,21 +48,24 @@ module GotGastro
         mail.body    = <<-BODY.gsub(/^ {10}/, '')
           The following new food safety warnings have been found within #{alert.distance}km of #{alert.address}.
 
-          #{format(offences)}
+          #{format(offences, Business.new(:lat => alert.lat, :lng => alert.lng))}
 
           Thanks,
           Got Gastro
 
-          Unsubscribe: #{@host}/alert/#{alert.confirmation_id}/unsubscribe
+          Unsubscribe: #{config['settings']['baseurl']}/alert/#{alert.confirmation_id}/unsubscribe
+          Change: #{config['settings']['baseurl']}/alert/#{alert.confirmation_id}/edit
         BODY
+
         GotGastro::Workers::EmailWorker.perform_async(mail)
       end
 
-      def format(offences)
+      def format(offences, origin)
         template = <<-TEMPLATE.gsub(/^ {10}/, '')
           <% offences.each do |offence| %>
           Business: <%= offence.business.name %>
           Address: <%= offence.business.address %>
+          Distance away: <%= "%.2f" % offence.business.distance_from(origin) %>km
           Date: <%= offence.date %>
           Description: <%= offence.description.strip %>
           <% end %>

--- a/lib/views/alert_edit.haml
+++ b/lib/views/alert_edit.haml
@@ -1,0 +1,52 @@
+- page_title 'Change alert for' + @alert.address
+
+%div.container
+  %div.row
+    %div.col-md-12
+      %h1
+        %i.fa.fa-check-circle-o
+        Change my alert
+      - if not flash.empty?
+        - flash.each do |level, message|
+          %div{:class => "alert alert-#{level} alert-dismissable"}
+            %button.close{:type => "button", 'data-dismiss' => 'alert', 'aria-label' => "Close"}
+              %span{'aria-hidden' => true} &times;
+            = message
+      %p
+        What size area near
+        %em= @alert.address
+        would you like to receive alerts for?
+      %form{:action => link_to("/alert/#{@alert.confirmation_id}/edit"), :method => "POST"}
+        %div.form-group
+          %div.radio
+            %label
+              %input{:type => 'radio', :name => 'alert[distance]', :value => '5', :checked => @alert.distance == 5}
+              Within 5km
+          %div.radio
+            %label
+              %input{:type => 'radio', :name => 'alert[distance]', :value => '10', :checked => @alert.distance == 10}
+              Within 10km
+          %div.radio
+            %label
+              %input{:type => 'radio', :name => 'alert[distance]', :value => '15', :checked => @alert.distance == 15}
+              Within 15km
+          %div.form-group
+            %button{:type => 'submit', :class => 'btn btn-success'}
+              Update size
+      %p
+        Don't want to receive this alert any more?
+      %p
+        %a{:href => "/alert/#{@alert.confirmation_id}/unsubscribe"}
+          %button.btn.btn-warning{:type => 'button'}
+            %i.fa.fa-fw.fa-trash
+            Unsubscribe from this alert
+
+  %div.row.nav
+    %div.col-md-12
+      %p
+        %a{:href => "/"}
+          %button.btn.btn-default{:type => 'button'}
+            %i.fa.fa-fw.fa-arrow-circle-o-left
+            Back to search
+
+  = haml :footer

--- a/spec/alerts_spec.rb
+++ b/spec/alerts_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'faker'
 
 include Rack::Test::Methods
 include Mail::Matchers
@@ -56,7 +57,7 @@ describe 'Alerts', :type => :feature do
     expect(page.body).to match(/your alert is now activated/i)
 
     # unsubscribe
-    unsubscribe_link  = confirmation_link.to_s.gsub(/confirm/, 'unsubscribe')
+    unsubscribe_link = confirmation_link.to_s.gsub(/confirm/, 'unsubscribe')
     visit(unsubscribe_link)
     expect(page.status_code).to be 200
     expect(page.body).to match(/you have unsubscribed from your alert/i)
@@ -101,10 +102,8 @@ describe 'Alerts', :type => :feature do
     GotGastro::Workers::EmailAlerts.drain
     GotGastro::Workers::EmailWorker.drain
 
-    expect(Mail::TestMailer.deliveries.size).to be 1
-    alert_mail = Mail::TestMailer.deliveries.first
-
-    expect(alert_mail).to_not be nil
+    expect(Mail::TestMailer.deliveries.size).to eq(1)
+    alert_mail = Mail::TestMailer.deliveries.pop
     expect(alert_mail.to).to eq([alert.email])
 
     businesses = Business.find_near(alert.location, :within => alert.distance)
@@ -264,6 +263,106 @@ describe 'Alerts', :type => :feature do
     expect(Mail::TestMailer.deliveries.size).to be 0
   end
 
-  it 'should allow changing the alert distance'
+  def offence_json_generator(opts={})
+    options = {
+      :count => 10,
+      :within => 15,
+      :origin => origin,
+    }.merge(opts)
 
+    business_ids = Business.find_near(origin, :within => options[:within], :limit => nil).map(:id)
+
+    offences = (0..options[:count]).map { |i|
+      {
+        'business_id' => i >= business_ids.size ? business_ids[0] : business_ids[i],
+        'date' => Faker::Time.backward(14).to_date,
+        'link' => Faker::Internet.url('www2.health.vic.gov.au/public-health/food-safety/convictions-register'),
+        'description' => Faker::ChuckNorris.fact,
+      }
+    }
+
+    offences.to_json
+  end
+
+  it 'should allow changing the alert distance' do
+    stub_request(:get,
+      %r{https://api\.morph\.io/auxesis/gotgastro_scraper/data\.json\?key=.*&query=select%20\*%20from%20'businesses'}
+      ).to_return(:status => 200, :body => business_json)
+
+    stub_request(:get,
+      %r{https://api\.morph\.io/auxesis/gotgastro_scraper/data\.json\?key.*&query=select%20\*%20from%20'offences'}
+      ).to_return(:status => 200, :body => offence_json).then.
+        to_return(lambda { |request| {:body => offence_json_generator(:count => 20, :within => 15)} })
+
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+
+    alert = subscribed_user[:alert]
+
+    # first
+    # trigger import
+    visit "/reset?token=#{gastro_reset_token}"
+    GotGastro::Workers::Import.drain
+    expect(GotGastro::Workers::EmailAlerts.jobs.size).to be > 0
+
+    GotGastro::Workers::EmailAlerts.drain
+    GotGastro::Workers::EmailWorker.drain
+
+    # look at received mail
+    expect(Mail::TestMailer.deliveries.size).to be 1
+    alert_mail = Mail::TestMailer.deliveries.pop
+    expect(alert_mail.to).to eq([alert.email])
+
+    # change the size
+    edit_link = alert_mail.body.to_s.match(/(http.*edit)$/, 1).to_s
+    visit(edit_link)
+    choose('15km')
+    click_on 'Update size'
+
+
+
+    time_travel_to('tomorrow')
+
+    # second
+    # trigger import
+    visit "/reset?token=#{gastro_reset_token}"
+    GotGastro::Workers::Import.drain
+    expect(GotGastro::Workers::EmailAlerts.jobs.size).to be > 0
+
+    GotGastro::Workers::EmailAlerts.drain
+    GotGastro::Workers::EmailWorker.drain
+
+    # look at received mail
+    expect(Mail::TestMailer.deliveries.size).to be 1
+    alert_mail = Mail::TestMailer.deliveries.pop
+
+    expect(alert_mail.to).to eq([alert.email])
+    distances = alert_mail.body.to_s.split("\n").grep(/^Distance away: /).map {|d| d[/ (\d\.\d\d)km$/, 1].to_f}
+    expect(distances.size).to be > 0
+    distances.each do |distance|
+      expect(distance).to be < 15
+    end
+
+    time_travel_to('tomorrow')
+
+    # third
+    # trigger import
+    visit "/reset?token=#{gastro_reset_token}"
+    GotGastro::Workers::Import.drain
+    expect(GotGastro::Workers::EmailAlerts.jobs.size).to be > 0
+
+    GotGastro::Workers::EmailAlerts.drain
+    GotGastro::Workers::EmailWorker.drain
+
+    # look at received mail
+    expect(Mail::TestMailer.deliveries.size).to eq(1)
+    alert_mail = Mail::TestMailer.deliveries.pop
+
+    expect(alert_mail.to).to eq([alert.email])
+    distances = alert_mail.body.to_s.split("\n").grep(/^Distance away: /).map {|d| d[/ (\d\.\d\d)km$/, 1].to_f}
+    expect(distances.size).to be > 0
+    distances.each do |distance|
+      expect(distance).to be < 15
+    end
+  end
 end


### PR DESCRIPTION
An Alert defaults to looking for offences for businesses within 5km. 

This PR allows users to change the search radius to 5, 10, or 15km. 