### PR TITLE
Fix formatting of detailed offences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'foreman'
 gem 'newrelic_rpm'
 gem 'dotiw'
 gem 'addressable'
+gem 'redcarpet'
 
 group :development do
   gem 'rerun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redcarpet (3.3.4)
     redis (3.3.1)
     rerun (0.11.0)
       listen (~> 3.0)
@@ -219,6 +220,7 @@ DEPENDENCIES
   rack-google-analytics
   rack-ssl
   rake
+  redcarpet
   rerun
   rest-client
   rspec
@@ -231,7 +233,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.3.0p0
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/lib/gotgastro/workers/import_worker.rb
+++ b/lib/gotgastro/workers/import_worker.rb
@@ -15,13 +15,21 @@ module GotGastro
         # Create Businesses
         Business.unrestrict_primary_key
         businesses.each do |business|
-          Business.create(business) unless Business[business['id']]
+          if b = Business[business['id']]
+            b.update(business)
+          else
+            Business.create(business)
+          end
         end
 
         # Create Offences
         Offence.unrestrict_primary_key
         offences.each do |offence|
-          Offence.create(offence) unless Offence.first(:link => offence['link'])
+          if o = Offence.first(:link => offence['link'])
+            o.update(offence)
+          else
+            Offence.create(offence)
+          end
         end
 
         import.save

--- a/lib/views/detail.haml
+++ b/lib/views/detail.haml
@@ -48,7 +48,8 @@
           Details of offences
       - if @business.offences.map {|o| o.description }.join =~ /\n/
         - @business.offences.each do |offence|
-          %pre= offence.description
+          :markdown
+            #{offence.description}
       - else
         %ul
           - @business.offences.each do |offence|


### PR DESCRIPTION
Fixes #10.

Render offence details with Markdown, so: 

 - notice text displays with paragraphs
 - notice text does not overflow the bounding box
 - notice text does not require horizontal scrolling to read

Before:

![image](https://cloud.githubusercontent.com/assets/12306/19829588/7d023160-9e31-11e6-9ed8-e247ecb9c143.png)

After: 

![image](https://cloud.githubusercontent.com/assets/12306/19829584/6151c8b8-9e31-11e6-88b5-2b6fa4f1b2e0.png)
