### PR TITLE
Improve web performance with CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _site/
 dump.rdb
 log
 node_modules/
+capybara-*.html

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
   gem 'rerun'
   gem 'pry'
   gem 'mailcatcher'
+  gem 'launchy'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     i18n (0.7.0)
     ice_nine (0.11.2)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -214,6 +216,7 @@ DEPENDENCIES
   foreman
   geokit
   haml
+  launchy
   mail
   mailcatcher
   mysql2

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -31,7 +31,7 @@ def production?
 end
 
 def cdn?
-  !!config['cdn_base']
+  !!config['settings']['cdn_base']
 end
 
 def debug(msg)

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -26,6 +26,10 @@ def info?
   environment != 'test'
 end
 
+def production?
+  environment == 'production'
+end
+
 def debug(msg)
   puts('[debug] ' + msg) if debug?
 end

--- a/lib/gotgastro/initializer.rb
+++ b/lib/gotgastro/initializer.rb
@@ -30,6 +30,10 @@ def production?
   environment == 'production'
 end
 
+def cdn?
+  !!config['cdn_base']
+end
+
 def debug(msg)
   puts('[debug] ' + msg) if debug?
 end
@@ -65,11 +69,12 @@ def config
 
   # FIXME(auxesis): refactor this to recursive openstruct
   settings = {}
-  settings['baseurl'] = environment == 'production' ? 'https://gotgastroagain.com' : 'http://localhost:9292'
+  settings['baseurl'] = production? ? 'https://gotgastroagain.com' : 'http://localhost:9292'
+  settings['cdn_base'] = ENV['CDN_BASE']
   begin
     set_or_error(settings, 'reset_token',   :env => 'GASTRO_RESET_TOKEN')
     set_or_error(settings, 'morph_api_key', :env => 'MORPH_API_KEY')
-    set_or_error(settings, 'newrelic_license_key', :env => 'NEWRELIC_LICENSE_KEY') if environment == 'production'
+    set_or_error(settings, 'newrelic_license_key', :env => 'NEWRELIC_LICENSE_KEY') if production?
   rescue ArgumentError => e
     @vcap = nil
     raise e

--- a/lib/gotgastro/views/alerts/email_html.haml
+++ b/lib/gotgastro/views/alerts/email_html.haml
@@ -30,8 +30,10 @@
             = business.address
 
           %p
+            - # FIXME(auxesis): refactor map generation into a helper
             - img_src = "https://maps.googleapis.com/maps/api/staticmap?scale=2&zoom=15&size=200x100&amp;maptype=roadmap"
             - markers = "size:mid%7C#{business.lat},#{business.lng}"
+            - # FIXME(auxesis): refactor api key into a variable
             - gmaps_api_key = "AIzaSyBxaCRguM2pvw9HOLybx5ZP6Cuo94KnJwg"
             - map_url = "#{img_src}&markers=#{markers}&key=#{gmaps_api_key}"
             %img{:src => map_url}/

--- a/lib/gotgastro/views/detail.haml
+++ b/lib/gotgastro/views/detail.haml
@@ -1,6 +1,9 @@
 - page_title @business.name
+
+- # FIXME(auxesis): refactor map generation into a helper
 - img_src = "https://maps.googleapis.com/maps/api/staticmap?scale=2&zoom=16&size=400x200&amp;maptype=roadmap"
 - markers = "size:mid%7C#{@business.lat},#{@business.lng}"
+- # FIXME(auxesis): refactor api key into a variable
 - gmaps_api_key = "AIzaSyBxaCRguM2pvw9HOLybx5ZP6Cuo94KnJwg"
 - map_url = "#{img_src}&markers=#{markers}&key=#{gmaps_api_key}"
 

--- a/lib/gotgastro/views/index.haml
+++ b/lib/gotgastro/views/index.haml
@@ -48,6 +48,6 @@
   = haml :footer
 
 
--# FIXME(auxesis): refactor this into a variable
+-# FIXME(auxesis): refactor api key into a variable
 - google_api_key = 'AIzaSyDBvlmNsUERDKkeQWX6OCsfR5VoPaD3nWo'
 %script{:src => "https://maps.googleapis.com/maps/api/js?key=#{google_api_key}&libraries=places&callback=initAutocomplete",:async => :async, :defer => :defer}

--- a/lib/gotgastro/views/index.haml
+++ b/lib/gotgastro/views/index.haml
@@ -50,4 +50,4 @@
 
 -# FIXME(auxesis): refactor api key into a variable
 - google_api_key = 'AIzaSyDBvlmNsUERDKkeQWX6OCsfR5VoPaD3nWo'
-%script{:src => "https://maps.googleapis.com/maps/api/js?key=#{google_api_key}&libraries=places&callback=initAutocomplete",:async => :async, :defer => :defer}
+- require_js("https://maps.googleapis.com/maps/api/js?key=#{google_api_key}&libraries=places&callback=initAutocomplete",:async => :async, :defer => :defer)

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -8,10 +8,10 @@
     = include_page_title
     // FIXME(auxesis): add helpers to set page description
     %meta{:content => 'Got Gastro helps you find out about potential food safety problems when eating out or buying food.'}
-    // FIXME(auxesis): add helpers to link css (with absolute url)
-    %link{:href => link_to('/css/vendor/font-awesome.min.css'), :rel => 'stylesheet'}/
-    %link{:href => link_to('/css/vendor/bootstrap.min.css'), :rel => 'stylesheet'}/
-    %link{:href => link_to('/css/main.min.css'), :rel => 'stylesheet'}/
+    - require_css('vendor/font-awesome.min')
+    - require_css('vendor/bootstrap.min')
+    - require_css('vendor/main.min')
+    = include_required_css
     // FIXME(auxesis): add helpers to link canonical (with absolute url)
     %link{:href => link_to('/'), :rel => 'canonical'}/
     %link{:href => link_to('/img/favicon.png?1'), :rel => 'icon'}/

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -1,23 +1,23 @@
 !!!
-%html{:lang => "en"}
+%html{:lang => 'en'}
   %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %meta{:charset => "utf-8"}/
-    %meta{:content => "IE=edge", "http-equiv" => "X-UA-Compatible"}/
-    %meta{:content => "width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no", :name => "viewport"}/
+    %meta{:content => 'text/html; charset=UTF-8', 'http-equiv' => 'Content-Type'}/
+    %meta{:charset => 'utf-8'}/
+    %meta{:content => 'IE=edge', 'http-equiv' => 'X-UA-Compatible'}/
+    %meta{:content => 'width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no', :name => 'viewport'}/
     = include_page_title
     // FIXME(auxesis): add helpers to set page description
-    %meta{:content => "Got Gastro helps you find out about potential food safety problems when eating out or buying food."}
+    %meta{:content => 'Got Gastro helps you find out about potential food safety problems when eating out or buying food.'}
     // FIXME(auxesis): add helpers to link css (with absolute url)
-    %link{:href => link_to("/css/vendor/font-awesome.min.css"), :rel => "stylesheet"}/
-    %link{:href => link_to("/css/vendor/bootstrap.min.css"), :rel => "stylesheet"}/
-    %link{:href => link_to("/css/main.min.css"), :rel => "stylesheet"}/
+    %link{:href => link_to('/css/vendor/font-awesome.min.css'), :rel => 'stylesheet'}/
+    %link{:href => link_to('/css/vendor/bootstrap.min.css'), :rel => 'stylesheet'}/
+    %link{:href => link_to('/css/main.min.css'), :rel => 'stylesheet'}/
     // FIXME(auxesis): add helpers to link canonical (with absolute url)
-    %link{:href => link_to("/"), :rel => "canonical"}/
-    %link{:href => link_to("/img/favicon.png?1"), :rel => "icon"}/
-    %link{:href => link_to("/img/apple-touch-icon-precomposed.png?1"), :rel => "apple-touch-icon-precomposed"}/
+    %link{:href => link_to('/'), :rel => 'canonical'}/
+    %link{:href => link_to('/img/favicon.png?1'), :rel => 'icon'}/
+    %link{:href => link_to('/img/apple-touch-icon-precomposed.png?1'), :rel => 'apple-touch-icon-precomposed'}/
     // FIXME(auxesis): add helpers to link javascript (with absolute url)
-    %script{:src => link_to("/js/vendor/jquery.min.js")}
+    %script{:src => link_to('/js/vendor/jquery.min.js')}
     = include_required_js
   %body
     = yield

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -18,7 +18,6 @@
     %link{:href => link_to("/img/apple-touch-icon-precomposed.png?1"), :rel => "apple-touch-icon-precomposed"}/
     // FIXME(auxesis): add helpers to link javascript (with absolute url)
     %script{:src => link_to("/js/vendor/jquery.min.js")}
-    %script{:src => link_to("/js/vendor/bootstrap.min.js")}
     = include_required_js
   %body
     = yield

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -17,7 +17,8 @@
     %link{:href => link_to('/img/favicon.png?1'), :rel => 'icon'}/
     %link{:href => link_to('/img/apple-touch-icon-precomposed.png?1'), :rel => 'apple-touch-icon-precomposed'}/
     // FIXME(auxesis): add helpers to link javascript (with absolute url)
-    %script{:src => link_to('/js/vendor/jquery.min.js')}
-    = include_required_js
   %body
     = yield
+
+    %script{:src => link_to('/js/vendor/jquery.min.js')}
+    = include_required_js

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -16,9 +16,8 @@
     %link{:href => link_to('/'), :rel => 'canonical'}/
     %link{:href => link_to('/img/favicon.png?1'), :rel => 'icon'}/
     %link{:href => link_to('/img/apple-touch-icon-precomposed.png?1'), :rel => 'apple-touch-icon-precomposed'}/
-    // FIXME(auxesis): add helpers to link javascript (with absolute url)
+    - require_js('vendor/jquery.min')
   %body
     = yield
 
-    %script{:src => link_to('/js/vendor/jquery.min.js')}
     = include_required_js

--- a/lib/gotgastro/views/search.haml
+++ b/lib/gotgastro/views/search.haml
@@ -4,10 +4,12 @@
   - page_title "Search results near: #{@location.address}"
 
 - require_js 'search.min'
+- # FIXME(auxesis): refactor map generation into a helper
 - zoom = @businesses.size == 0 ? "&zoom=10" : ""
 - img_src = "https://maps.googleapis.com/maps/api/staticmap?scale=2#{zoom}&size=400x200&amp;maptype=roadmap"
 - markers = "size:tiny%7C#{@businesses.map {|p|[p.lat,p.lng].join(',')}.join('%7C')}"
 - markers += "&markers=icon:http://i.stack.imgur.com/orZ4x.png%7C#{@location.lat},#{@location.lng}"
+- # FIXME(auxesis): refactor api key into a variable
 - gmaps_api_key = "AIzaSyBxaCRguM2pvw9HOLybx5ZP6Cuo94KnJwg"
 - map_url = "#{img_src}&markers=#{markers}&key=#{gmaps_api_key}"
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -148,7 +148,7 @@ module Sinatra
     def include_required_css
       if @css_filenames
         @css_filenames.map { |filename|
-          %(<link href="#{link_to("/css/#{filename}.css")}" rel="stylesheet" type="text/css">)
+          %(<link href="#{link_to("/css/#{filename}.css", :asset => true)}" rel="stylesheet" type="text/css">)
         }.join("\n")
       else
         ""

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -122,14 +122,21 @@ module Sinatra
 
     def include_required_js
       if @js_filenames
-        @js_filenames.map { |filename, opts|
+        @js_filenames.sort_by {|f,o| f =~ /^vendor/ ? 0 : 1 }.map { |filename, opts|
           type = opts[:type] ? opts[:type] : 'text/javascript'
-          %(<script src="#{link_to("/js/#{filename}.js")}" type="#{type}"></script>)
+          # if the path is absolute, insert in directly
+          if filename =~ /^http/
+            attrs = opts.map{|k,v| %(#{k}="#{v}")}.join(' ')
+            %(<script src="#{filename}" type="#{type}" #{attrs}></script>)
+          else
+            %(<script src="#{link_to("/js/#{filename}.js", :asset => true)}" type="#{type}"></script>)
+          end
         }.join("\n")
       else
         ""
       end
     end
+
   end
 
   module RequireCSSHelper

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -163,7 +163,7 @@ module Sinatra
       case
       # if thing being linked to is an asset, and CDN is configured, link to CDN
       when opts[:asset] && cdn?
-        base = config['cdn_base']
+        base = config['settings']['cdn_base']
       when options[:mode] == :path_only
         base = request.script_name
       when options[:mode] == :full_url

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -158,11 +158,15 @@ module Sinatra
 
   module LinkToHelper
     # from http://gist.github.com/98310
-    def link_to(url_fragment, mode=:path_only)
-      case mode
-      when :path_only
+    def link_to(url_fragment, opts={})
+      options = { :mode => :path_only }.merge(opts)
+      case
+      # if thing being linked to is an asset, and CDN is configured, link to CDN
+      when opts[:asset] && cdn?
+        base = config['cdn_base']
+      when options[:mode] == :path_only
         base = request.script_name
-      when :full_url
+      when options[:mode] == :full_url
         if (request.scheme == 'http' && request.port == 80 ||
             request.scheme == 'https' && [80, 443].include?(request.port))
           port = ""

--- a/spec/alerts_spec.rb
+++ b/spec/alerts_spec.rb
@@ -9,6 +9,8 @@ describe 'Alerts', :type => :feature do
 
   before(:each) do
     Mail::TestMailer.deliveries.clear
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
   end
 
   it 'should allow a user to subscribe' do

--- a/spec/business_search_spec.rb
+++ b/spec/business_search_spec.rb
@@ -4,6 +4,12 @@ include Rack::Test::Methods
 
 describe 'Business search', :type => :feature do
   include_context 'test data'
+
+  before(:each) do
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+  end
+
   it 'should only show results in the surrounding 25km' do
     within_25km && within_150km
 

--- a/spec/cdn_spec.rb
+++ b/spec/cdn_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'faker'
+
+include Rack::Test::Methods
+
+describe 'CDN', :type => :feature do
+  include_context 'test data'
+
+  def query(attrs)
+    q = Addressable::URI.new.query_values = attrs
+    q.to_query
+  end
+
+  let(:cdn_base) { "https://" + Faker::Internet.domain_name }
+
+  before(:each) do
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+  end
+
+  describe 'enabled' do
+    it 'should serve JavaScript from a CDN' do
+      set_environment_variable('CDN_BASE', cdn_base)
+
+      visit '/'
+
+      doc = Nokogiri::HTML(page.body)
+      scripts = doc.search('script').map { |tag| tag.attributes['src'].value }
+      scripts.each do |value|
+        next if value =~ /maps.googleapis.com/
+        expect(value).to match(/^#{cdn_base}/)
+      end
+    end
+
+    it 'should serve CSS from a CDN' do
+      set_environment_variable('CDN_BASE', cdn_base)
+
+      visit '/'
+
+      doc = Nokogiri::HTML(page.body)
+      links = doc.search("//link[@type='text/css']").map do |tag|
+        tag.attributes['href'].value
+      end
+      links.each do |value|
+        expect(value).to match(/^#{cdn_base}/)
+      end
+    end
+  end
+
+  describe 'disabled' do
+    it 'should not serve JavaScript from a CDN' do
+      delete_environment_variable('CDN_BASE')
+
+      visit '/'
+
+      doc = Nokogiri::HTML(page.body)
+      scripts = doc.search('script').map { |tag| tag.attributes['src'].value }
+      scripts.each do |value|
+        next if value =~ /maps.googleapis.com/
+        expect(value).to_not match(/^#{cdn_base}/)
+      end
+    end
+
+    it 'should not serve CSS from a CDN' do
+      delete_environment_variable('CDN_BASE')
+
+      visit '/'
+
+      doc = Nokogiri::HTML(page.body)
+      links = doc.search("//link[@type='text/css']").map do |tag|
+        tag.attributes['href'].value
+      end
+      links.each do |value|
+        expect(value).to_not match(/^#{cdn_base}/)
+      end
+    end
+  end
+end

--- a/spec/cdn_spec.rb
+++ b/spec/cdn_spec.rb
@@ -45,6 +45,8 @@ describe 'CDN', :type => :feature do
         expect(value).to match(/^#{cdn_base}/)
       end
     end
+
+    it 'should serve images from a CDN'
   end
 
   describe 'disabled' do
@@ -74,5 +76,7 @@ describe 'CDN', :type => :feature do
         expect(value).to_not match(/^#{cdn_base}/)
       end
     end
+
+    it 'should not serve images from a CDN'
   end
 end

--- a/spec/location_tracking_spec.rb
+++ b/spec/location_tracking_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 include Rack::Test::Methods
 
 describe 'Location tracking', :type => :feature do
+  include_context 'test data'
+
+  before(:each) do
+    set_environment_variable('GASTRO_RESET_TOKEN', gastro_reset_token)
+    set_environment_variable('MORPH_API_KEY', morph_api_key)
+  end
+
   it 'should default to Sydney' do
     visit '/search'
     expect(find('img')['src'].include?('-33.8675,151.207')).to be true


### PR DESCRIPTION
Based on results of YSlow on [gotgastroagain.com](https://gotgastroagain.com):

- Add ability to serve content from a CDN.
- Load all JavaScript at the bottom of the document, to minimise their blocking of the main page thread.
- Normalise ordering of content, so common, vendored things are loaded first, then anything specific to a page.
- Ensure any JavaScript and CSS are marked as assets, so they can potentially be served by CDN.

Fixes #38.