### PR TITLE
Add Twitter cards to search and detail

### DIFF
--- a/lib/gotgastro.rb
+++ b/lib/gotgastro.rb
@@ -47,7 +47,8 @@ module GotGastro
     end
 
     get '/search' do
-      @businesses = Business.find_near(@location,:within => 25).all
+      @businesses_dataset = Business.find_near(@location,:within => 25)
+      @businesses = @businesses_dataset.all
       haml :search
     end
 

--- a/lib/gotgastro/views/detail.haml
+++ b/lib/gotgastro/views/detail.haml
@@ -1,4 +1,11 @@
 - page_title @business.name
+- meta_tag :name => 'twitter:card', :content => 'summary_large_image'
+- meta_tag :name => 'twitter:site', :content => '@gotgastro'
+- severity = @business.has_major_offences? ? 'major' : 'minor'
+- problem = @business.problems == 1 ? 'problem' : 'problems'
+- meta_tag :name => 'twitter:title', :content => "#{@business.name}: #{@business.problems} #{severity} food safety #{problem}"
+- opts = { :highest_measure_only => true, :accumulate_on => :years }
+- meta_tag :name => 'twitter:description', :content => "Located at #{@business.address}. Last problem was #{time_ago_in_words(@business.last_offence.date, opts)} ago."
 
 - # FIXME(auxesis): refactor map generation into a helper
 - img_src = "https://maps.googleapis.com/maps/api/staticmap?scale=2&zoom=16&size=400x200&amp;maptype=roadmap"
@@ -6,6 +13,8 @@
 - # FIXME(auxesis): refactor api key into a variable
 - gmaps_api_key = "AIzaSyBxaCRguM2pvw9HOLybx5ZP6Cuo94KnJwg"
 - map_url = "#{img_src}&markers=#{markers}&key=#{gmaps_api_key}"
+- meta_tag :name => 'twitter:image', :content => map_url
+- meta_tag :name => 'twitter:image:alt', :content => "Map showing location of the business, at #{@business.address}"
 
 %div.container
   %h1= @business.name

--- a/lib/gotgastro/views/layout.haml
+++ b/lib/gotgastro/views/layout.haml
@@ -5,14 +5,15 @@
     %meta{:charset => 'utf-8'}/
     %meta{:content => 'IE=edge', 'http-equiv' => 'X-UA-Compatible'}/
     %meta{:content => 'width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no', :name => 'viewport'}/
+    = include_meta
     = include_page_title
-    // FIXME(auxesis): add helpers to set page description
+    - # FIXME(auxesis): add helpers to set page description
     %meta{:content => 'Got Gastro helps you find out about potential food safety problems when eating out or buying food.'}
     - require_css('vendor/font-awesome.min')
     - require_css('vendor/bootstrap.min')
     - require_css('main.min')
     = include_required_css
-    // FIXME(auxesis): add helpers to link canonical (with absolute url)
+    - # FIXME(auxesis): add helpers to link canonical (with absolute url)
     %link{:href => link_to('/'), :rel => 'canonical'}/
     %link{:href => link_to('/img/favicon.png?1', :asset => true), :rel => 'icon'}/
     %link{:href => link_to('/img/apple-touch-icon-precomposed.png?1', :asset => true), :rel => 'apple-touch-icon-precomposed'}/

--- a/lib/gotgastro/views/search.haml
+++ b/lib/gotgastro/views/search.haml
@@ -3,6 +3,23 @@
 - else
   - page_title "Search results near: #{@location.address}"
 
+- # FIXME(auxesis): refactor all this data generation into separate methods
+- meta_tag :name => 'twitter:card', :content => 'summary_large_image'
+- meta_tag :name => 'twitter:site', :content => '@gotgastro'
+- problem = @businesses.size == 1 ? 'problem' : 'problems'
+- title = "#{@businesses.size} food safety #{problem}"
+- title += " near #{@location.address}" unless @location.address.blank?
+- meta_tag :name => 'twitter:title', :content => title
+- if @businesses.size > 0
+  - nearest  = "%.1f" % @businesses.first.distance_from(@location)
+  - furthest = "%.1f" % @businesses.last.distance_from(@location)
+  - latest   = @businesses_dataset.unordered.offences.order(:date).last
+  - opts = { :highest_measure_only => true, :accumulate_on => :years }
+  - description = "Nearest #{nearest}km away. Furthest #{furthest}km away. Latest problem was #{time_ago_in_words(latest.date, opts)} ago."
+- else
+  - description = "No businesses found in search"
+- meta_tag :name => 'twitter:description', :content => description
+
 - require_js 'search.min'
 - # FIXME(auxesis): refactor map generation into a helper
 - zoom = @businesses.size == 0 ? "&zoom=10" : ""
@@ -12,6 +29,8 @@
 - # FIXME(auxesis): refactor api key into a variable
 - gmaps_api_key = "AIzaSyBxaCRguM2pvw9HOLybx5ZP6Cuo94KnJwg"
 - map_url = "#{img_src}&markers=#{markers}&key=#{gmaps_api_key}"
+- meta_tag :name => 'twitter:image', :content => map_url
+- meta_tag :name => 'twitter:image:alt', :content => "Map showing location of food safety problems near #{@location.address}"
 
 %div.container
   %h1

--- a/spec/alerts_spec.rb
+++ b/spec/alerts_spec.rb
@@ -145,8 +145,8 @@ describe 'Alerts', :type => :feature do
     expect(alert_mail.to).to eq([alert.email])
 
     businesses = Business.find_near(alert.location, :within => alert.distance)
-    conditions = { Sequel.qualify(:offences, :created_at) => Time.now.beginning_of_day..Time.now.end_of_day }
-    offences = Offence.join(businesses, :id => :business_id).where{conditions}.all
+    conditions = ['offences.created_at >= :alert', {:alert => alert.created_at}]
+    offences   = Offence.join(businesses, :id => :business_id).where(*conditions).all
     business_count = offences.map(&:business).uniq.size
 
     expect(alert_mail.subject).to match(alert.address)


### PR DESCRIPTION
Per #47, search results should be more social. 

This is what the card looks like for search results:

![image](https://cloud.githubusercontent.com/assets/12306/20037313/36e1c182-a471-11e6-9ba1-0242eee640d7.png)

And this is a business:

![image](https://cloud.githubusercontent.com/assets/12306/20037314/44cfe242-a471-11e6-854b-5ee1afe31304.png)
